### PR TITLE
feat: better error handling

### DIFF
--- a/nordigen_lib/__init__.py
+++ b/nordigen_lib/__init__.py
@@ -118,7 +118,7 @@ def get_or_create_requisition(fn_create, fn_initiate, fn_remove, requisitions, r
     if not requisition:
         requisition = fn_create(
             **{
-                "redirect": "http://127.0.0.1/",
+                "redirect": "https://127.0.0.1/",
                 "reference": reference,
                 "enduser_id": enduser_id,
                 "agreements": [],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -156,7 +156,7 @@ class TestRequisition(unittest.TestCase):
             "id": "foobar-id",
         }
         fn_initiate.return_value = {
-            "initiate": "http://example.com/whatever",
+            "initiate": "https://example.com/whatever",
         }
 
         res = get_or_create_requisition(
@@ -175,7 +175,7 @@ class TestRequisition(unittest.TestCase):
         )
 
         fn_create.assert_called_with(
-            redirect="http://127.0.0.1/",
+            redirect="https://127.0.0.1/",
             reference="ref",
             enduser_id="user",
             agreements=[],
@@ -184,7 +184,7 @@ class TestRequisition(unittest.TestCase):
         self.assertEqual(
             {
                 "id": "foobar-id",
-                "initiate": "http://example.com/whatever",
+                "initiate": "https://example.com/whatever",
                 "requires_auth": True,
             },
             res,
@@ -203,7 +203,7 @@ class TestRequisition(unittest.TestCase):
             "id": "foobar-id",
         }
         fn_initiate.return_value = {
-            "initiate": "http://example.com/whatever",
+            "initiate": "https://example.com/whatever",
         }
 
         res = get_or_create_requisition(
@@ -219,7 +219,7 @@ class TestRequisition(unittest.TestCase):
 
         fn_remove.assert_not_called()
         fn_create.assert_called_with(
-            redirect="http://127.0.0.1/",
+            redirect="https://127.0.0.1/",
             reference="ref",
             enduser_id="user",
             agreements=[],
@@ -228,7 +228,7 @@ class TestRequisition(unittest.TestCase):
         self.assertEqual(
             {
                 "id": "foobar-id",
-                "initiate": "http://example.com/whatever",
+                "initiate": "https://example.com/whatever",
                 "requires_auth": True,
             },
             res,
@@ -247,7 +247,7 @@ class TestRequisition(unittest.TestCase):
         }
 
         fn_initiate.return_value = {
-            "initiate": "http://example.com/whatever",
+            "initiate": "https://example.com/whatever",
         }
 
         res = get_or_create_requisition(
@@ -273,7 +273,7 @@ class TestRequisition(unittest.TestCase):
             {
                 "id": "req-id",
                 "status": "not-LN",
-                "initiate": "http://example.com/whatever",
+                "initiate": "https://example.com/whatever",
                 "requires_auth": True,
             },
             res,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ class TestIntegration(unittest.TestCase):
             "status": "CR",
         }
 
-        clinet_instance.requisitions.initiate.return_value = {"initiate": "http://example.com/whoohooo"}
+        clinet_instance.requisitions.initiate.return_value = {"initiate": "https://example.com/whoohooo"}
 
         entry(hass=hass, config=config, CONST=const, LOGGER=LOGGER)
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -569,7 +569,7 @@ class TestBuildUnconfirmedSensor:
             "id": "req-id",
             "enduser_id": "user-123",
             "reference": "ref-123",
-            "initiate": "http://whatever.com",
+            "initiate": "https://whatever.com",
             "config": "config",
         }
 


### PR DESCRIPTION
now handle suspended (SU) and unknown (EX) requisitions. If
either case encountered the requisition will be removed and
recreated to avoid throwing errors later in the process.